### PR TITLE
Update omni.mdx - remove Trash Pushes in Omni

### DIFF
--- a/docs/variant-specific/omni.mdx
+++ b/docs/variant-specific/omni.mdx
@@ -23,13 +23,6 @@ These conventions apply to any variant with an omni (touched by all clues) suit.
   - Alice gives a _Play Clue_ to an omni 3 in Cathy's hand.
   - Bob knows that he is _Prompted_ for the omni 2. He plays the number 1 card (as opposed to blind-playing slot 1 as a _Finesse_).
 
-### Trash Pushes in Omni
-
-- When a _Trash Push_ happens in a normal variant, if more than one card is touched, then all of the touched cards are known to be trash.
-- When a _Trash Push_ happens in a variant with an omni suit, if more than one card is touched, it is possible that only the card on chop was trash, and that the other cards touched are useful / critical omni cards.
-- In this situation, after blind-playing the _Trash Pushed_ card, the player should first discard the card that initiated the _Trash Push_ (the oldest card) and then hold on to the other touched cards.
-  - In this situation, _Good Touch Principle_ applies to the other touched cards. The other members of the team must give a _Fix Clue_ to those cards if they are also trash.
-
 ### Mud Clues
 
 - [_Mud Clues_](muddy-rainbow-cocoa-rainbow.mdx#mud-clues) (from muddy rainbow variants) also apply to omni cards.


### PR DESCRIPTION
omni now inherits the trash moves conventions from pink